### PR TITLE
test: add fixtures to support snowflake-cli tests

### DIFF
--- a/apps/DE_PROJECT_1/app/python/procedures_man.py
+++ b/apps/DE_PROJECT_1/app/python/procedures_man.py
@@ -15,7 +15,7 @@ from pathlib import Path
 #   apps/DE_PROJECT_1/tests/test_procedures_man.py
 # Keep this module runtime-only.
 
-# Dynamically add the project root to PYTHONPATH before any repo-local imports...
+# Dynamically add the project root to PYTHONPATH before any repo-local imports....
 ROOT_DIR = os.path.abspath(os.path.join(
     os.path.dirname(__file__), "../../../"))
 if ROOT_DIR not in sys.path:


### PR DESCRIPTION
This is the first commit after the rollback of the refactor of the reject handling within the DE_PROJECT_1 app. This included  fixed for pytest  and a problem with role being duplicated in the snowflake connection and linter issues. The goal here is to get the app back to a working status for rejects... get that wotking (even if not the ideal design) and then again approach the refactor to generalize the reject handline fo all apps in this repo.